### PR TITLE
Misc fixes

### DIFF
--- a/ceph/ceph/templates/bin/_osd_disk_prepare.sh.tpl
+++ b/ceph/ceph/templates/bin/_osd_disk_prepare.sh.tpl
@@ -44,8 +44,8 @@ function osd_disk_prepare {
     fi
   fi
 
-  if [[ ${OSD_BLUESTORE} -eq 1 ]]; then
-    ceph-disk -v prepare ${CLI_OPTS} --bluestore ${OSD_DEVICE}
+  if [[ ${OSD_BLUESTORE} -eq 0 ]]; then
+    ceph-disk -v prepare ${CLI_OPTS} --filestore ${OSD_DEVICE}
   elif [[ ${OSD_DMCRYPT} -eq 1 ]]; then
     # the admin key must be present on the node
     if [[ ! -e $ADMIN_KEYRING ]]; then

--- a/ceph/ceph/values.yaml
+++ b/ceph/ceph/values.yaml
@@ -184,57 +184,15 @@ conf:
     append:
     config:
       global:
-        # auth
-        cephx: true
-        cephx_require_signatures: false
-        cephx_cluster_require_signatures: true
-        cephx_service_require_signatures: false
-
         max_open_files: 131072
         osd_pool_default_pg_num: 128
         osd_pool_default_pgp_num: 128
-        osd_pool_default_size: 3
-        osd_pool_default_min_size: 1
-        mon_osd_full_ratio: .95
-        mon_osd_nearfull_ratio: .85
         mon_host: null
-      mon:
-        mon_osd_down_out_interval: 600
-        mon_osd_min_down_reporters: 4
-        mon_clock_drift_allowed: .15
-        mon_clock_drift_warn_backoff: 30
-        mon_osd_report_timeout: 300
       osd:
-        journal_size: 100
-        osd_mkfs_type: xfs
-        osd_mkfs_options_xfs: -f -i size=2048
-        osd_mon_heartbeat_interval: 30
-        osd_max_object_name_len: 256
-        #crush
-        osd_pool_default_crush_rule: 0
-        osd_crush_update_on_start: true
-        osd_crush_chooseleaf_type: 1
-        #backend
-        osd_objectstore: filestore
-        #performance tuning
-        filestore_merge_threshold: 40
-        filestore_split_multiple: 8
-        osd_op_threads: 8
-        filestore_op_threads: 8
-        filestore_max_sync_interval: 5
-        osd_max_scrubs: 1
-        #recovery tuning
-        osd_recovery_max_active: 5
-        osd_max_backfills: 2
-        osd_recovery_op_priority: 2
-        osd_client_op_priority: 63
-        osd_recovery_threads: 1
         #ports
         ms_bind_port_min: 6800
         ms_bind_port_max: 7100
       client:
-        rbd_cache_enabled: true
-        rbd_cache_writethrough_until_flush: true
         rbd_default_features: "1"
       mds:
         mds_cache_size: 100000

--- a/ceph/ceph/values.yaml
+++ b/ceph/ceph/values.yaml
@@ -23,9 +23,9 @@ images:
   ks_user: docker.io/kolla/ubuntu-source-heat-engine:3.0.3
   ks_service: docker.io/kolla/ubuntu-source-heat-engine:3.0.3
   ks_endpoints: docker.io/kolla/ubuntu-source-heat-engine:3.0.3
-  bootstrap: quay.io/attcomdev/ceph-daemon:tag-build-master-jewel-ubuntu-16.04
+  bootstrap: docker.io/ceph/daemon:tag-build-master-luminous-ubuntu-16.04
   dep_check: docker.io/kolla/ubuntu-source-kubernetes-entrypoint:4.0.0
-  daemon: quay.io/attcomdev/ceph-daemon:tag-build-master-jewel-ubuntu-16.04
+  daemon: docker.io/ceph/daemon:tag-build-master-luminous-ubuntu-16.04
   ceph_config_helper: docker.io/port/ceph-config-helper:v1.7.5
   rbd_provisioner: quay.io/external_storage/rbd-provisioner:v0.1.1
   pull_policy: "IfNotPresent"


### PR DESCRIPTION
The first commit update the docker image from Jewel to Luminous. Since BlueStore is default with Luminous we reverse the logic for ceph-disk prepare. Note that $OSD_BLUESTORE is unchanged (still 0).

Second commit removes a lot of clutter in the ceph.conf. Most are already defaults. Not sure why ms_bind_port_max was ever changed from default, so leaving it there for now. 