### PR TITLE
storageclass: add imageFormat and imageFeature support

### DIFF
--- a/ceph/ceph/templates/storageclass.yaml
+++ b/ceph/ceph/templates/storageclass.yaml
@@ -31,5 +31,7 @@ parameters:
     pool: {{ .Values.storageclass.pool }}
     userId: {{ .Values.storageclass.user_id }}
     userSecretName: {{ .Values.storageclass.user_secret_name }}
+    imageFormat: {{ .Values.storageclass.image_format | quote }}
+    imageFeatures: {{ .Values.storageclass.image_features }}
 {{- end }}
 {{- end }}

--- a/ceph/ceph/values.yaml
+++ b/ceph/ceph/values.yaml
@@ -337,6 +337,8 @@ storageclass:
   admin_secret_namespace: ceph
   user_id: admin
   user_secret_name: pvc-ceph-client-key
+  image_format: "2"
+  image_features: layering
 
 endpoints:
   cluster_domain_suffix: cluster.local


### PR DESCRIPTION
rbd-provisioner provisions image format 1. This PR makes that configurable and defines defaults. 

Before merging I think this needs review to figure out the lowest common denominator for the kernels we want to support. I think that's layering but would appreciate inputs.


