### PR TITLE
ceph-mgr: localpool support

### DIFF
--- a/ceph/ceph/templates/bin/_start_mgr.sh.tpl
+++ b/ceph/ceph/templates/bin/_start_mgr.sh.tpl
@@ -39,6 +39,25 @@ if [[ "$MGR_DASHBOARD" == 1 ]]; then
     ceph ${CLI_OPTS} config-key put mgr/dashboard/server_port "$MGR_PORT"
 fi
 
+if [[ "$LOCAL_POOL" == 1 ]]; then
+    ceph ${CLI_OPTS} mgr module enable localpool --force
+    if [ -n "${LPOOL_FAILURE_DOMAIN}" ]; then
+        ceph ${CLI_OPTS} config-key set mgr/localpool/failure_domain ${LPOOL_FAILURE_DOMAIN}
+    fi
+    if [ -n "${LPOOL_SUBTREE}" ]; then
+        ceph ${CLI_OPTS} config-key set mgr/localpool/subtree ${LPOOL_SUBTREE}
+    fi
+    if [ -n "${LPOOL_PG_NUM}" ]; then
+        ceph ${CLI_OPTS} config-key set mgr/localpool/pg_num ${LPOOL_PG_NUM}
+    fi
+    if [ -n "${LPOOL_NUM_REP}" ]; then
+        ceph ${CLI_OPTS} config-key set mgr/localpool/num_rep ${LPOOL_NUM_REP}
+    fi
+    if [ -n "${LPOOL_MIN_SIZE}" ]; then
+        ceph ${CLI_OPTS} config-key set mgr/localpool/min_size ${LPOOL_MIN_SIZE}
+    fi
+fi
+
 log "SUCCESS"
 # start ceph-mgr
 exec /usr/bin/ceph-mgr $DAEMON_OPTS -i "$MGR_NAME"

--- a/ceph/ceph/templates/deployment-mgr.yaml
+++ b/ceph/ceph/templates/deployment-mgr.yaml
@@ -66,6 +66,14 @@ spec:
           imagePullPolicy: {{ .Values.images.pull_policy }}
 {{ tuple $envAll $envAll.Values.pod.resources.mgr | include "helm-toolkit.snippets.kubernetes_resources" | indent 10 }}
           env:
+          {{- if .Values.deployment.ceph_local_pool }}
+            - name: LOCAL_POOL
+              value: "1"
+          {{- range $key, $val := .Values.ceph_local_pool }}
+            - name: LPOOL_{{ $key | upper }}
+              value: {{ $val | quote }}
+          {{- end}}
+          {{- end }}
             - name: MGR_PORT
               value: "{{ .Values.network.port.mgr }}"
           command:

--- a/ceph/ceph/values.yaml
+++ b/ceph/ceph/values.yaml
@@ -18,6 +18,7 @@ deployment:
   client_secrets: true
   rbd_provisioner: true
   rgw_keystone_user_and_endpoints: false
+  ceph_local_pool: false
 
 images:
   ks_user: docker.io/kolla/ubuntu-source-heat-engine:3.0.3
@@ -280,6 +281,13 @@ bootstrap:
       ceph osd pool stats $1 || ceph osd pool create $1 $2
     }
     ensure_pool volumes 8
+
+ceph_local_pool:
+  failure_domain: host
+  subtree: rack
+  pg_num: "128"
+  num_rep: "3"
+  min_size: "2"
 
 # if you change provision_storage_class to false
 # it is presumed you manage your own storage


### PR DESCRIPTION
Add localpool support. Disabled by default.

The current luminous docker image on docker hub doesn't support this. 
Tested with a self-built docker image built on Luminous head.