### PR TITLE
Add log-tailing containers for extra mon logs

### DIFF
--- a/ceph/ceph/templates/bin/_log_handler.sh.tpl
+++ b/ceph/ceph/templates/bin/_log_handler.sh.tpl
@@ -1,0 +1,15 @@
+#!/bin/sh
+# for busybox sh, which is dash
+
+LOG=$1
+DEFAULT_SIZE=$(expr 100 \* 1024 \* 1024)
+SIZE=${2:-${DEFAULT_SIZE}}
+
+/usr/bin/tail -F $1 &
+
+while true ; do
+    sleep 30
+    if [ $(/bin/stat -c%s $LOG) -gt $SIZE ] ; then
+        mv $LOG $LOG.1
+    fi
+done

--- a/ceph/ceph/templates/configmap-bin.yaml
+++ b/ceph/ceph/templates/configmap-bin.yaml
@@ -73,5 +73,7 @@ data:
 {{ tuple "bin/_check_zombie_mons.py.tpl" . | include  "helm-toolkit.utils.template" | indent 4 }}
   rbd-provisioner.sh: |
 {{ tuple "bin/_rbd-provisioner.sh.tpl" . | include  "helm-toolkit.utils.template" | indent 4 }}
+  log_handler.sh: |
+{{ tuple "bin/_log_handler.sh.tpl" . | include  "helm-toolkit.utils.template" | indent 4 }}
 {{- end }}
 {{- end }}

--- a/ceph/ceph/templates/daemonset-mon.yaml
+++ b/ceph/ceph/templates/daemonset-mon.yaml
@@ -57,6 +57,36 @@ spec:
               mountPath: /run
               readOnly: false
       containers:
+        {{- if not .Values.ceph.storage.mon_log }}
+        - name: cluster-audit-log-tailer
+          image: {{ .Values.images.minimal }}
+          imagePullPolicy: {{ .Values.images.pull_policy }}
+          command:
+            - /tmp/log_handler.sh
+          args:
+            - /var/log/ceph/ceph.audit.log
+          volumeMounts:
+            - name: pod-var-log-ceph
+              mountPath: /var/log/ceph
+              readOnly: false
+            - name: ceph-bin
+              mountPath: /tmp/log_handler.sh
+              subPath: log_handler.sh
+        - name: cluster-log-tailer
+          image: {{ .Values.images.minimal }}
+          imagePullPolicy: {{ .Values.images.pull_policy }}
+          command:
+            - /tmp/log_handler.sh
+          args:
+            - /var/log/ceph/ceph.log
+          volumeMounts:
+            - name: pod-var-log-ceph
+              mountPath: /var/log/ceph
+              readOnly: false
+            - name: ceph-bin
+              mountPath: /tmp/log_handler.sh
+              subPath: log_handler.sh
+        {{- end }}
         - name: ceph-mon
           image: {{ .Values.images.daemon }}
           imagePullPolicy: {{ .Values.images.pull_policy }}
@@ -143,11 +173,9 @@ spec:
             - name: pod-var-lib-ceph
               mountPath: /var/lib/ceph
               readOnly: false
-            {{- if .Values.ceph.storage.mon_log }}
             - name: pod-var-log-ceph
               mountPath: /var/log/ceph
               readOnly: false
-            {{- end }}
             - name: pod-run
               mountPath: /run
               readOnly: false
@@ -160,10 +188,12 @@ spec:
           configMap:
             name: ceph-etc
             defaultMode: 0444
-        {{- if .Values.ceph.storage.mon_log }}
         - name: pod-var-log-ceph
+        {{- if .Values.ceph.storage.mon_log }}
           hostPath:
             path: {{ .Values.ceph.storage.mon_log }}
+        {{- else }}
+          emptyDir: {}
         {{- end }}
         - name: pod-var-lib-ceph
           hostPath:

--- a/ceph/ceph/values.yaml
+++ b/ceph/ceph/values.yaml
@@ -29,6 +29,7 @@ images:
   daemon: docker.io/ceph/daemon:tag-build-master-luminous-ubuntu-16.04
   ceph_config_helper: docker.io/port/ceph-config-helper:v1.7.5
   rbd_provisioner: quay.io/external_storage/rbd-provisioner:v0.1.1
+  minimal: docker.io/alpine:latest
   pull_policy: "IfNotPresent"
 
 labels:
@@ -262,8 +263,8 @@ ceph:
     var_directory: /var/lib/openstack-helm/ceph/ceph
     mon_directory: /var/lib/openstack-helm/ceph/mon
     # use /var/log for fluentd to collect ceph log
-    mon_log: /var/log/ceph/mon
-    osd_log: /var/log/ceph/osd
+    # mon_log: /var/log/ceph/mon
+    # osd_log: /var/log/ceph/osd
 
 osd_directory:
   enabled: false


### PR DESCRIPTION
Use 'minimal' image (defaulting to Alpine) to add sidecar
containers to daemonset-mon, along with a small shell script,
to tail the 'extra' monitor logs (ceph.log and ceph.audit.log),
and watch them until they get greater than a certain size
(default 100MB), at which point rename them (to retain one
level of backup log inside the container).  This is simplistic
log rotation because the primary logging happens through Kubernetes.
Also, the daemon isn't signaled to reopen the logs because
it opens the files exclusively for each log message (unlike the
main log, which is assumed to be coming to stderr from the
primary ceph-mon container).

Signed-off-by: Dan Mick <dmick@redhat.com>