### PR TITLE
Add job to delete ceph admin keys

### DIFF
--- a/ceph/ceph/templates/bin/_ceph-storage-admin-key-cleaner.sh.tpl
+++ b/ceph/ceph/templates/bin/_ceph-storage-admin-key-cleaner.sh.tpl
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+
+for secret in $CEPH_ADMIN_SECRETS_NAME; do
+  kubectl delete secret \
+  --namespace ${DEPLOYMENT_NAMESPACE} \
+  --ignore-not-found=true \
+  ${secret}
+done
+
+kubectl delete secret \
+  --namespace ${DEPLOYMENT_NAMESPACE} \
+  --ignore-not-found=true \
+  ${PVC_CEPH_STORAGECLASS_ADMIN_SECRET_NAME}

--- a/ceph/ceph/templates/configmap-bin.yaml
+++ b/ceph/ceph/templates/configmap-bin.yaml
@@ -75,5 +75,7 @@ data:
 {{ tuple "bin/_rbd-provisioner.sh.tpl" . | include  "helm-toolkit.utils.template" | indent 4 }}
   log_handler.sh: |
 {{ tuple "bin/_log_handler.sh.tpl" . | include  "helm-toolkit.utils.template" | indent 4 }}
+  ceph-storage-admin-key-cleaner.sh: |+
+{{ tuple "bin/_ceph-storage-admin-key-cleaner.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
 {{- end }}
 {{- end }}

--- a/ceph/ceph/templates/job-admin-key-cleaner.yaml
+++ b/ceph/ceph/templates/job-admin-key-cleaner.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.manifests.job_storage_admin_keys_cleaner }}
+{{- $envAll := . }}
+{{- if .Values.deployment.storage_secrets }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ceph-storage-admin-key-cleaner-{{ randAlphaNum 5 | lower }}
+  annotations:
+    "helm.sh/hook": pre-delete
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $envAll "ceph" "admin-key-cleaner" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      nodeSelector:
+        {{ $envAll.Values.labels.jobs.node_selector_key }}: {{ $envAll.Values.labels.jobs.node_selector_value }}
+      containers:
+        - name:  ceph-storage-admin-keys-cleaner
+          image: {{ .Values.images.ceph_config_helper }}
+          imagePullPolicy: {{ .Values.images.pull_policy }}
+{{ tuple $envAll $envAll.Values.pod.resources.jobs.secret_provisioning | include "helm-toolkit.snippets.kubernetes_resources" | indent 10 }}
+          env:
+            - name: DEPLOYMENT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PVC_CEPH_STORAGECLASS_ADMIN_SECRET_NAME
+              value: {{ .Values.storageclass.admin_secret_name }}
+            - name: CEPH_ADMIN_SECRETS_NAME
+              value: |-
+          {{- range $key, $val := .Values.secrets.keyrings }}
+                {{ $val }}
+          {{- end }}
+          command:
+            - /opt/ceph/ceph-storage-admin-key-cleaner.sh
+          volumeMounts:
+            - name: ceph-bin
+              mountPath: /opt/ceph/ceph-storage-admin-key-cleaner.sh
+              subPath: ceph-storage-admin-key-cleaner.sh
+              readOnly: true
+      volumes:
+        - name: ceph-bin
+          configMap:
+            name: ceph-bin
+            defaultMode: 0555
+{{- end }}
+{{- end }}

--- a/ceph/ceph/values.yaml
+++ b/ceph/ceph/values.yaml
@@ -381,6 +381,7 @@ manifests:
   job_namespace_client_key_cleaner: true
   job_namespace_client_key: true
   job_storage_admin_keys: true
+  job_storage_admin_keys_cleaner: true
   secret_keystone_rgw: true
   secret_keystone: true
   service_mon: true


### PR DESCRIPTION
This will delete the secrets for mon.keyring, bootstrap-{osd,mds,rgw}, client.admin, and the admin secret for the storageclass. 
@rootfs @dmick not sure "admin" is the best name for all that. Any suggestion?