### PR TITLE
Update readme Installation doc link

### DIFF
--- a/ceph/README.rst
+++ b/ceph/README.rst
@@ -26,4 +26,4 @@ We use GitHub to maintain this project:
 Installation
 ------------
 
-The installation documentation is available on `ceph.com <http://docs.ceph.com/start/kube-helm/>`_.
+The installation documentation is available on `ceph.com <http://docs.ceph.com/docs/master/start/kube-helm/>`_.


### PR DESCRIPTION
Actual location is http://docs.ceph.com/docs/master/start/kube-helm/

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>