### PR TITLE
add ceph-command job

### DIFF
--- a/ceph/ceph/templates/bin/_exec_ceph_commands.sh.tpl
+++ b/ceph/ceph/templates/bin/_exec_ceph_commands.sh.tpl
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+export LC_ALL=C
+
+MON_NAME=$(kubectl get pods --namespace=${NAMESPACE} -l application=ceph,component=mon -o template --template="{{`{{ with index .items 0}}`}}{{`{{ .metadata.name}}`}}{{`{{end}}`}}")
+
+# Define field separator to ';' and
+# store commands in a bash array
+IFS=';' read -ra CEPH_COMMANDS <<< "${CEPH_COMMANDS_LIST}"
+for ceph_command in "${CEPH_COMMANDS[@]}"; do
+    kubectl --namespace=${NAMESPACE} exec ${MON_NAME} -c ceph-mon -- $ceph_command
+done

--- a/ceph/ceph/templates/configmap-bin.yaml
+++ b/ceph/ceph/templates/configmap-bin.yaml
@@ -77,5 +77,7 @@ data:
 {{ tuple "bin/_ceph-storage-admin-key-cleaner.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
   check_mgr.sh: |+
 {{ tuple "bin/_check_mgr.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
+  exec_ceph_commands.sh: |+
+{{ tuple "bin/_exec_ceph_commands.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
 {{- end }}
 {{- end }}

--- a/ceph/ceph/templates/job-ceph-commands.yaml
+++ b/ceph/ceph/templates/job-ceph-commands.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ceph_commands }}
+{{- $envAll := . }}
+{{- $dependencies := .Values.dependencies.ceph_commands }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ceph-commands-{{ randAlphaNum 5 | lower }}
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $envAll "ceph" "ceph-commands" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      nodeSelector:
+        {{ $envAll.Values.labels.jobs.node_selector_key }}: {{ $envAll.Values.labels.jobs.node_selector_value }}
+      initContainers:
+{{ tuple $envAll $dependencies "" | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+      containers:
+        - name: ceph-commands
+          image: {{ .Values.images.ceph_config_helper }}
+          imagePullPolicy: {{ .Values.images.pull_policy }}
+          env:
+            - name: CEPH_COMMANDS_LIST
+              value: {{ .Values.ceph_commands | join ";"  | quote }}
+          command:
+            - /exec_ceph_commands.sh
+          volumeMounts:
+            - name: ceph-bin
+              mountPath: /exec_ceph_commands.sh
+              subPath: exec_ceph_commands.sh
+              readOnly: true
+      volumes:
+        - name: ceph-bin
+          configMap:
+            name: ceph-bin
+            defaultMode: 0555
+{{- end}}

--- a/ceph/ceph/values.yaml
+++ b/ceph/ceph/values.yaml
@@ -241,6 +241,10 @@ dependencies:
     services:
     - service: ceph_mon
       endpoint: internal
+  ceph_commands:
+    services:
+    - service: ceph_mon
+      endpoint: internal
 
 ceph:
   rgw_keystone_auth: false
@@ -298,6 +302,14 @@ ceph_mgr_enabled_modules:
 #    pg_num: "128"
 #    num_rep: "3"
 #    min_size: "2"
+
+# You can run any ceph commands upon deployment
+# or upgrade by setting the following.
+# These will be executed via kubectl exec
+# Do *not* use ';' it is used internally as a delimiter
+#ceph_commands:
+# - ceph osd pool create <pool> <pg_num>
+# - ceph osd crush tunables <tunables>
 
 # if you change provision_storage_class to false
 # it is presumed you manage your own storage


### PR DESCRIPTION
Allows to run commands on a ceph cluster after installation
or during upgrade.

Signed-off-by: Alexandre Marangone <amarango@redhat.com>