### PR TITLE
Use the long form of commands/flags in Makefiles

### DIFF
--- a/ceph/Makefile
+++ b/ceph/Makefile
@@ -26,8 +26,8 @@ $(CHARTS):
 	@make $(TASK)-$@
 
 init-%:
-	if [ -f $*/Makefile ]; then make -C $*; fi
-	if [ -f $*/requirements.yaml ]; then helm dep up $*; fi
+	if [ -f $*/Makefile ]; then make --directory=$*; fi
+	if [ -f $*/requirements.yaml ]; then helm dependency update $*; fi
 
 lint-%: init-%
 	if [ -d $* ]; then $(HELM) lint $*; fi


### PR DESCRIPTION
Improve interpretability of Makefiles by using the long form of commands
and command flags.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>