### PR TITLE
Base64 decode and multi-line literals in yaml files

### DIFF
--- a/ceph/ceph/templates/bin/_ceph-key.sh.tpl
+++ b/ceph/ceph/templates/bin/_ceph-key.sh.tpl
@@ -43,8 +43,7 @@ metadata:
   name: ${KUBE_SECRET_NAME}
 type: Opaque
 data:
-  ${CEPH_KEYRING_NAME}: |
-    $( kube_ceph_keyring_gen ${CEPH_KEYRING} ${CEPH_KEYRING_TEMPLATE} )
+  ${CEPH_KEYRING_NAME}: $( kube_ceph_keyring_gen ${CEPH_KEYRING} ${CEPH_KEYRING_TEMPLATE} )
 EOF
     } | kubectl create --namespace ${DEPLOYMENT_NAMESPACE} -f -
   fi

--- a/ceph/ceph/templates/bin/_ceph-namespace-client-key.sh.tpl
+++ b/ceph/ceph/templates/bin/_ceph-namespace-client-key.sh.tpl
@@ -31,8 +31,7 @@ metadata:
   name: "${PVC_CEPH_STORAGECLASS_USER_SECRET_NAME}"
 type: kubernetes.io/rbd
 data:
-  key: |
-    $(echo ${CEPH_KEY})
+  key: $(echo ${CEPH_KEY})
 EOF
   } | kubectl create --namespace ${kube_namespace} -f -
 }

--- a/ceph/ceph/templates/bin/_ceph-storage-key.sh.tpl
+++ b/ceph/ceph/templates/bin/_ceph-storage-key.sh.tpl
@@ -46,8 +46,7 @@ metadata:
   name: ${KUBE_SECRET_NAME}
 type: Opaque
 data:
-  ${CEPH_KEYRING_NAME}: |
-    $( kube_ceph_keyring_gen ${CEPH_KEYRING} ${CEPH_KEYRING_TEMPLATE} )
+  ${CEPH_KEYRING_NAME}: $( kube_ceph_keyring_gen ${CEPH_KEYRING} ${CEPH_KEYRING_TEMPLATE} )
 EOF
     } | kubectl create --namespace ${DEPLOYMENT_NAMESPACE} -f -
   fi
@@ -69,8 +68,7 @@ metadata:
   name: ${KUBE_SECRET_NAME}
 type: kubernetes.io/rbd
 data:
-  key: |
-    $( echo ${CEPH_KEYRING} | base64 | tr -d '\n' )
+  key: $( echo ${CEPH_KEYRING} | base64 | tr -d '\n' )
 EOF
     } | kubectl create --namespace ${DEPLOYMENT_NAMESPACE} -f -
   fi


### PR DESCRIPTION
The current shell templates create yaml files, which define multi-line strings using the literal block operator, i.e.:
```
key : |
  value
```

This seems to add a newline a the end of the value. On my box, base64 decode produces:
> Error from server (BadRequest): error when creating "STDIN": Secret in version "v1" cannot be handled as a Secret: v1.Secret: ObjectMeta: v1.ObjectMeta: TypeMeta: Kind: Data: decode base64: illegal base64 data at input byte 108, parsing 158 ...CoiCg==\n"... at {"apiVersion":"v1","data":{"ceph.mon.keyring":"W21vbi5dDQogIGtleSA9IHRvcHNlY3JldA0KICBjYXBzIG1vbiA9ICJhbGxvdyAqIg==\n"},"kind":"Secret","metadata":{"name":"ceph-mon-keyring","namespace":"ceph"},"type":"Opaque"}

I have changed multi-line literals to single line literals where base64 data is used as values. This should be correct for base64 data, which is always a single line since `tr -d '\n'` is applied. After the changes ceph is deployed correctly.