### PR TITLE
Fix device occasionally not exist after doing parted

### DIFF
--- a/ceph/ceph/templates/bin/_osd_disk_prepare.sh.tpl
+++ b/ceph/ceph/templates/bin/_osd_disk_prepare.sh.tpl
@@ -20,6 +20,8 @@ function osd_disk_prepare {
 
   # search for some ceph metadata on the disk
   if [[ "$(parted --script ${OSD_DEVICE} print | egrep '^ 1.*ceph data')" ]]; then
+    # parted will trigger udev, so make sure all current udev event be handled.
+    udevadm settle
     log "It looks like ${OSD_DEVICE} is already an OSD"
     log "Checking if it belongs to this cluster"
     tmp_osd_mount="/var/lib/ceph/tmp/`echo $RANDOM`/"

--- a/ceph/ceph/templates/bin/_osd_disks.sh.tpl
+++ b/ceph/ceph/templates/bin/_osd_disks.sh.tpl
@@ -57,6 +57,8 @@ function osd_disks {
     OSD_DEV="/dev/$(echo ${OSD_DISK}|sed 's/\(.*\):\(.*\)/\2/')"
 
     if [[ "$(parted --script ${OSD_DEV} print | egrep '^ 1.*ceph data')" ]]; then
+      # parted will trigger udev, so make sure all current udev event be handled.
+      udevadm settle
       if [[ ${OSD_FORCE_ZAP} -eq 1 ]]; then
         ceph-disk -v zap ${OSD_DEV}
       else

--- a/ceph/ceph/templates/bin/_start_osd.sh.tpl
+++ b/ceph/ceph/templates/bin/_start_osd.sh.tpl
@@ -19,6 +19,8 @@ function osd_trying_to_determine_scenario {
     source osd_directory.sh
     osd_directory
   elif $(parted --script ${OSD_DEVICE} print | egrep -sq '^ 1.*ceph data'); then
+    # parted will trigger udev, so make sure all current udev event be handled.
+    udevadm settle
     log "Bootstrapped OSD found; activating ${OSD_DEVICE}"
     source osd_disk_activate.sh
     osd_activate


### PR DESCRIPTION
I use `parted` command to do some tests:
```
parted -s /dev/sdd print > /dev/null;  for i in `seq 1 1000` ;
> do ls -alh /dev/sdd13 >/dev/null || echo $i: not found sdd13 ; done
```

Occasionally, the test maybe faild like:
```
ls: cannot access /dev/sdd13: No such file or directory
1: not found sdd13
```

And, through the `udevadm monitor` output:
```
KERNEL[1126040.921247] remove   /devices/pci0000:00/0000:00:01.0/0000:02:00.0/host0/target0:0:3/0:0:3:0/block/sdd/sdd13 (block)
KERNEL[1126040.927888] change   /devices/pci0000:00/0000:00:01.0/0000:02:00.0/host0/target0:0:3/0:0:3:0/block/sdd (block)
KERNEL[1126040.928020] add      /devices/pci0000:00/0000:00:01.0/0000:02:00.0/host0/target0:0:3/0:0:3:0/block/sdd/sdd13 (block)
UDEV  [1126040.929398] remove   /devices/pci0000:00/0000:00:01.0/0000:02:00.0/host0/target0:0:3/0:0:3:0/block/sdd/sdd13 (block)
UDEV  [1126040.942840] change   /devices/pci0000:00/0000:00:01.0/0000:02:00.0/host0/target0:0:3/0:0:3:0/block/sdd (block)
UDEV  [1126040.957819] add      /devices/pci0000:00/0000:00:01.0/0000:02:00.0/host0/target0:0:3/0:0:3:0/block/sdd/sdd13 (block)
```

Seems like, the device is lost after being removed by udev(or kernel),
and, reappear after being added.

Add `udevadm settle` to make sure all current udev event be handled.

Signed-off-by: Linggang Zeng <linggang.zeng@easystack.cn>