### PR TITLE
start_mon: use --monmap instead of --inject-monmap in mkfs

### DIFF
--- a/ceph/ceph/templates/bin/_start_mon.sh.tpl
+++ b/ceph/ceph/templates/bin/_start_mon.sh.tpl
@@ -79,7 +79,7 @@ if [[ (! -e "${MON_DATA_DIR}/keyring") && (! -e "${MON_DATA_DIR}/done") ]]; then
   done
 
   # Prepare the monitor daemon's directory with the map and keyring
-  ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} --mkfs -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
+  ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} --mkfs -i ${MON_NAME} --monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
 
   touch ${MON_DATA_DIR}/done
 else


### PR DESCRIPTION
When we are going to mkfs in creating mon data, we want to inject our monmap generated local
to mon db store.

But the --inject-monmap is wrong parameter for this. If we specify mkfs, the --inject-monmap
will be ignored. Instead, in this case, we need to use --monmap.

Reference: http://docs.ceph.com/docs/mimic/rados/operations/add-or-rm-mons/

Signed-off-by: Dongsheng Yang <dongsheng.yang@easystack.cn>